### PR TITLE
Add Server Side event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Typescript/Express API for proxying requests to Spinitron for WNYU
 ## Deployment
 
 This API is currently deployed at https://lobster-app-zabc8.ondigitalocean.app/,
-using the digital ocean app platform. 
+using the digital ocean app platform.
 NOTE: The environment variable for HOST must be set to '0.0.0.0' in the application
 settings in order for digital ocean to pass the HTTP health check

--- a/src/handlers/metadataHandlers.ts
+++ b/src/handlers/metadataHandlers.ts
@@ -1,0 +1,53 @@
+import type { SpinitronMetadata, Client } from '../types';
+import type { Request, Response } from 'express';
+
+let metadata: SpinitronMetadata = {};
+let clients: Client[] = [];
+
+function sendEventsToAll(newMetadata: SpinitronMetadata) {
+  clients.forEach((client) =>
+    client.res.write(`data: ${JSON.stringify(newMetadata)}\n\n`),
+  );
+}
+
+const postMetadata = async (req: Request, res: Response) => {
+  try {
+    const newMetadata = req.body as SpinitronMetadata;
+    metadata = newMetadata;
+    res.json(newMetadata);
+    return sendEventsToAll(newMetadata);
+  } catch (error) {
+    res.status(500).send({ error: 'An error occurred while fetching data.' });
+  }
+};
+
+const streamMetadata = (req: Request, res: Response) => {
+  try {
+    const headers = {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'no-cache',
+    };
+    res.writeHead(200, headers);
+    const data = `data: ${JSON.stringify(metadata)}\n\n`;
+    res.write(data);
+    const clientId = Date.now();
+    const newClient = {
+      id: clientId,
+      res,
+    };
+
+    clients.push(newClient);
+
+    req.on('close', () => {
+      clients = clients.filter((client) => client.id !== clientId);
+    });
+  } catch (error) {
+    res.status(500).send({ error: 'An error occurred while sending data' });
+  }
+};
+
+export const metadataHandlers = {
+  postMetadata,
+  streamMetadata,
+};

--- a/src/routers/healthCheckRouter.ts
+++ b/src/routers/healthCheckRouter.ts
@@ -1,8 +1,9 @@
 import express from 'express';
+import type { Request, Response } from 'express';
 
 const healthCheckRouter = express.Router({});
 
-healthCheckRouter.get('/', async (_req, res, _next) => {
+healthCheckRouter.get('/', async (req: Request, res: Response) => {
   const healthcheck = {
     uptime: process.uptime(),
     message: 'OK',

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -3,6 +3,7 @@ import { personasRouter } from './personasRouter';
 import { showsRouter } from './showsRouter';
 import { playlistsRouter } from './playlistsRouter';
 import { spinsRouter } from './spinsRouter';
+import { metadataRouter } from './metadataRouter';
 import { healthCheckRouter } from './healthCheckRouter';
 
 const rootRouter = express.Router();
@@ -11,5 +12,7 @@ rootRouter.use('/personas', personasRouter);
 rootRouter.use('/shows', showsRouter);
 rootRouter.use('/playlists', playlistsRouter);
 rootRouter.use('/spins', spinsRouter);
+rootRouter.use('/metadata', metadataRouter);
 rootRouter.use('/', healthCheckRouter);
+
 export { rootRouter };

--- a/src/routers/metadataRouter.ts
+++ b/src/routers/metadataRouter.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { metadataHandlers } from '../handlers/metadataHandlers';
+
+const metadataRouter = express.Router({});
+
+metadataRouter.post('/', metadataHandlers.postMetadata);
+metadataRouter.get('/', metadataHandlers.streamMetadata);
+export { metadataRouter };

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -1,0 +1,6 @@
+import type { Response } from 'express';
+
+export interface Client {
+  id: number;
+  res: Response<any, Record<string, any>>;
+}

--- a/src/types/SpinitronMetadata.ts
+++ b/src/types/SpinitronMetadata.ts
@@ -1,0 +1,14 @@
+export interface SpinitronMetadata {
+  song_name?: string;
+  playlist_id?: string;
+  spin_id?: string;
+  artist_name?: string;
+  release_title?: string;
+  release_year?: string;
+  cover_art_url?: string;
+  dj?: string;
+  show_id?: string;
+  playlist_start_time?: string;
+  playlist_end_time?: string;
+  playlist_tile?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './Client';
+export * from './SpinitronMetadata';


### PR DESCRIPTION
This commit adds a server-side event to the API[1] via the new metadataHandlers.ts file. A server-side event is a unidirectional stream that can send data to a client based on a server-side trigger, in this case a post request to the metadata endpoint. This is done to take advantage of spinitron's metadata push interface, which sends a post request containing a dearth of useful information about the latest logged spin every time a new spin is logged. In doing this, we are able to receive up-to-date information on the current stream without having to worry about repeatedly querying the spinitron API.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events