### PR TITLE
Modify Metadata Route

### DIFF
--- a/src/routers/metadataRouter.ts
+++ b/src/routers/metadataRouter.ts
@@ -3,6 +3,6 @@ import { metadataHandlers } from '../handlers/metadataHandlers';
 
 const metadataRouter = express.Router({});
 
-metadataRouter.post('/', metadataHandlers.postMetadata);
-metadataRouter.get('/', metadataHandlers.streamMetadata);
+metadataRouter.post('/push', metadataHandlers.postMetadata);
+metadataRouter.post('/', metadataHandlers.streamMetadata);
 export { metadataRouter };


### PR DESCRIPTION
For some inexplicable reason, the digitalocean app platform won't accomodate SSEs as GET requests, but will when they are POST requests [1]. This commit switches the stream handler to a POST request and seems to function as desired. I will be keeping an eye on this

[1] https://www.digitalocean.com/community/questions/does-app-platform-support-sse-server-sent-events-application