### PR TITLE
Remove SSE from metadata routes

### DIFF
--- a/src/handlers/metadataHandlers.ts
+++ b/src/handlers/metadataHandlers.ts
@@ -1,17 +1,10 @@
 import { getLogger } from '../logger';
-import type { SpinitronMetadata, Client } from '../types';
+import type { SpinitronMetadata } from '../types';
 import type { NextFunction, Request, Response } from 'express';
 
 const logger = getLogger(__filename);
 
 let metadata: SpinitronMetadata = {};
-let clients: Client[] = [];
-
-function sendEventsToAll(newMetadata: SpinitronMetadata) {
-  clients.forEach((client) =>
-    client.res.write(`data: ${JSON.stringify(newMetadata)}\n\n`),
-  );
-}
 
 const postMetadata = async (
   req: Request,
@@ -22,40 +15,14 @@ const postMetadata = async (
     const newMetadata = req.body as SpinitronMetadata;
     metadata = newMetadata;
     res.json(newMetadata);
-    return sendEventsToAll(newMetadata);
   } catch (error) {
     next(error);
   }
 };
 
-const streamMetadata = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
+const getMetadata = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    logger.info(req);
-    const headers = {
-      'Content-Type': 'text/event-stream',
-      Connection: 'keep-alive',
-      'Cache-Control': 'no-cache',
-      'X-Accel-Buffering': 'no',
-    };
-    res.writeHead(200, headers);
-    const data = `data: ${JSON.stringify(metadata)}\n\n`;
-    res.write(data);
-    logger.info(data);
-    const clientId = Date.now();
-    const newClient = {
-      id: clientId,
-      res,
-    };
-
-    clients.push(newClient);
-
-    req.on('close', () => {
-      clients = clients.filter((client) => client.id !== clientId);
-    });
+    res.json(metadata);
   } catch (error) {
     next(error);
   }
@@ -63,5 +30,5 @@ const streamMetadata = async (
 
 export const metadataHandlers = {
   postMetadata,
-  streamMetadata,
+  getMetadata,
 };

--- a/src/routers/metadataRouter.ts
+++ b/src/routers/metadataRouter.ts
@@ -3,6 +3,6 @@ import { metadataHandlers } from '../handlers/metadataHandlers';
 
 const metadataRouter = express.Router({});
 
-metadataRouter.post('/push', metadataHandlers.postMetadata);
-metadataRouter.post('/', metadataHandlers.streamMetadata);
+metadataRouter.post('/', metadataHandlers.postMetadata);
+metadataRouter.get('/', metadataHandlers.getMetadata);
 export { metadataRouter };

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -1,6 +1,0 @@
-import type { Response } from 'express';
-
-export interface Client {
-  id: number;
-  res: Response<any, Record<string, any>>;
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,1 @@
-export * from './Client';
 export * from './SpinitronMetadata';


### PR DESCRIPTION
This commit dumps the sse approach from previous commits in the metadataHandlers in favor of a simpler caching approach. Now, the getMetadata route will just return the most recently pushed song, which is set by spinitron calls. To update, we will just be polling repeatedly on the front-end every 5 seconds or so.