### PR TITLE
Add schedule caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/express": "^4.17.21",
         "@typescript-eslint/eslint-plugin": "^7.10.0",
         "@typescript-eslint/parser": "^7.10.0",
+        "@wnyu/spinitron-sdk": "^1.0.3",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
@@ -593,6 +594,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
+    "node_modules/@wnyu/spinitron-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wnyu/spinitron-sdk/-/spinitron-sdk-1.0.3.tgz",
+      "integrity": "sha512-21KRQVHoIfPIeMNKGf0qOtN/h8stVC+wKx9l1WNgXnMIGoCf4C7b0P67OAZ4aF6Yq0VGSHhHM82l5byVQyYQ6A==",
       "dev": true
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/express": "^4.17.21",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
+    "@wnyu/spinitron-sdk": "^1.0.3",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^18.0.0",

--- a/src/handlers/metadataHandlers.ts
+++ b/src/handlers/metadataHandlers.ts
@@ -1,8 +1,5 @@
-import { getLogger } from '../logger';
 import type { SpinitronMetadata } from '../types';
 import type { NextFunction, Request, Response } from 'express';
-
-const logger = getLogger(__filename);
 
 let metadata: SpinitronMetadata = {};
 

--- a/src/handlers/showsHandlers.ts
+++ b/src/handlers/showsHandlers.ts
@@ -1,4 +1,51 @@
 import type { NextFunction, Request, Response } from 'express';
+import type { Show, ShowsResponse } from '@wnyu/spinitron-sdk';
+import { getLogger } from '../logger';
+
+const logger = getLogger(__filename);
+
+// Cache variable to store the upcoming shows for the next day
+let upcoming: ShowsResponse | undefined = undefined;
+
+const UPCOMING_CACHE_DURATION = 30*60*1000; 
+
+async function fetchUpcoming() {
+  try {
+    const start = new Date().toISOString();
+    const end = new Date(
+      new Date().setDate(new Date().getDate() + 1),
+    ).toISOString();
+    const searchParams = new URLSearchParams({
+      start,
+      end,
+    }).toString();
+    const url = `${process.env.SPINITRON_API_URL}/shows?${searchParams}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
+    });
+    const showData = (await response.json()) as ShowsResponse;
+    upcoming = showData;
+    logger.info(`Schedule updated at ${start}`);
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+setInterval(fetchUpcoming, UPCOMING_CACHE_DURATION);
+
+fetchUpcoming();
+
+const getUpcoming = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    res.send(upcoming);
+  } catch (error) {
+    next(error);
+  }
+};
 
 const getShows = async (
   req: Request,
@@ -42,4 +89,5 @@ const getShowById = async (
 export const showsHandlers = {
   getShows,
   getShowById,
+  getUpcoming,
 };

--- a/src/routers/showsRouter.ts
+++ b/src/routers/showsRouter.ts
@@ -5,5 +5,6 @@ const showsRouter = express.Router();
 
 showsRouter.get('/', showsHandlers.getShows);
 showsRouter.get('/:id', showsHandlers.getShowById);
+showsRouter.get('/schedule/upcoming', showsHandlers.getUpcoming);
 
 export { showsRouter };


### PR DESCRIPTION
This commit adds an in-memory cache of a list of scheduled programs between the time of request and the next day. This allows to poll our api instead of spinitron, and reduces the number of requests to the spinitron api to only 1 per cache interval