### PR TITLE
Add playlist cache

### DIFF
--- a/src/handlers/playlistsHandlers.ts
+++ b/src/handlers/playlistsHandlers.ts
@@ -1,4 +1,45 @@
+import { PlaylistsResponse } from '@wnyu/spinitron-sdk';
 import type { NextFunction, Request, Response } from 'express';
+import { getLogger } from '../logger';
+const logger = getLogger(__filename);
+
+// Cache variable to store the current playlist
+let currentPlaylist: PlaylistsResponse | undefined = undefined;
+
+const UPCOMING_CACHE_DURATION = 5 * 60 * 1000;
+
+async function fetchCurrentPlaylist() {
+  try {
+    const searchParams = new URLSearchParams({
+      count: '1',
+    }).toString();
+    const url = `${process.env.SPINITRON_API_URL}/playlists?${searchParams}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
+    });
+    const playlistData = (await response.json()) as PlaylistsResponse;
+    currentPlaylist = playlistData;
+    logger.info(`Playlist updated at ${Date.now()}`);
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+setInterval(fetchCurrentPlaylist, UPCOMING_CACHE_DURATION);
+
+fetchCurrentPlaylist();
+
+const getCurrentPlaylist = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    res.send(currentPlaylist);
+  } catch (error) {
+    next(error);
+  }
+};
 
 const getPlaylists = async (
   req: Request,
@@ -42,4 +83,5 @@ const getPlaylistById = async (
 export const playlistsHandlers = {
   getPlaylists,
   getPlaylistById,
+  getCurrentPlaylist,
 };

--- a/src/routers/playlistsRouter.ts
+++ b/src/routers/playlistsRouter.ts
@@ -5,5 +5,7 @@ const playlistsRouter = express.Router();
 
 playlistsRouter.get('/', playlistsHandlers.getPlaylists);
 playlistsRouter.get('/:id', playlistsHandlers.getPlaylistById);
+playlistsRouter.get('/current/playlist', playlistsHandlers.getCurrentPlaylist);
+
 
 export { playlistsRouter };


### PR DESCRIPTION
This commit adds a cache for the most recent playlist, refreshed every 5 minutes. Notably, for our use cases in the front-end, we will want a link to the most recent Playlist, not show, as that playlist will contain the tracklist that was just logged