### PR TITLE
Refactor Caches into Stores

### DIFF
--- a/src/handlers/metadataHandlers.ts
+++ b/src/handlers/metadataHandlers.ts
@@ -1,7 +1,6 @@
 import type { SpinitronMetadata } from '@wnyu/spinitron-sdk';
 import type { NextFunction, Request, Response } from 'express';
-
-let metadata: SpinitronMetadata = {};
+import { metadataStore } from '../stores';
 
 const postMetadata = async (
   req: Request,
@@ -10,7 +9,7 @@ const postMetadata = async (
 ) => {
   try {
     const newMetadata = req.body as SpinitronMetadata;
-    metadata = newMetadata;
+    metadataStore.setData(newMetadata);
     res.json(newMetadata);
   } catch (error) {
     next(error);
@@ -19,7 +18,7 @@ const postMetadata = async (
 
 const getMetadata = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    res.json(metadata);
+    res.json(metadataStore.getData());
   } catch (error) {
     next(error);
   }
@@ -29,5 +28,3 @@ export const metadataHandlers = {
   postMetadata,
   getMetadata,
 };
-
-export { metadata };

--- a/src/handlers/playlistsHandlers.ts
+++ b/src/handlers/playlistsHandlers.ts
@@ -1,33 +1,5 @@
-import { PlaylistsResponse } from '@wnyu/spinitron-sdk';
 import type { NextFunction, Request, Response } from 'express';
-import { getLogger } from '../logger';
-const logger = getLogger(__filename);
-
-// Cache variable to store the current playlist
-let currentPlaylist: PlaylistsResponse | undefined = undefined;
-
-const UPCOMING_CACHE_DURATION = 5 * 60 * 1000;
-
-async function fetchCurrentPlaylist() {
-  try {
-    const searchParams = new URLSearchParams({
-      count: '1',
-    }).toString();
-    const url = `${process.env.SPINITRON_API_URL}/playlists?${searchParams}`;
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
-    });
-    const playlistData = (await response.json()) as PlaylistsResponse;
-    currentPlaylist = playlistData;
-    logger.info(`Playlist updated at ${Date.now()}`);
-  } catch (error) {
-    logger.error(error);
-  }
-}
-
-setInterval(fetchCurrentPlaylist, UPCOMING_CACHE_DURATION);
-
-fetchCurrentPlaylist();
+import { currentPlaylistStore } from '../stores';
 
 const getCurrentPlaylist = async (
   req: Request,
@@ -35,7 +7,7 @@ const getCurrentPlaylist = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    res.send(currentPlaylist);
+    res.send(currentPlaylistStore.getData());
   } catch (error) {
     next(error);
   }
@@ -85,5 +57,3 @@ export const playlistsHandlers = {
   getPlaylistById,
   getCurrentPlaylist,
 };
-
-export { currentPlaylist };

--- a/src/handlers/showsHandlers.ts
+++ b/src/handlers/showsHandlers.ts
@@ -1,39 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import type { Show, ShowsResponse } from '@wnyu/spinitron-sdk';
-import { getLogger } from '../logger';
-
-const logger = getLogger(__filename);
-
-// Cache variable to store the upcoming shows for the next day
-let upcoming: ShowsResponse | undefined = undefined;
-
-const UPCOMING_CACHE_DURATION = 30*60*1000; 
-
-async function fetchUpcoming() {
-  try {
-    const start = new Date().toISOString();
-    const end = new Date(
-      new Date().setDate(new Date().getDate() + 1),
-    ).toISOString();
-    const searchParams = new URLSearchParams({
-      start,
-      end,
-    }).toString();
-    const url = `${process.env.SPINITRON_API_URL}/shows?${searchParams}`;
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
-    });
-    const showData = (await response.json()) as ShowsResponse;
-    upcoming = showData;
-    logger.info(`Schedule updated at ${start}`);
-  } catch (error) {
-    logger.error(error);
-  }
-}
-
-setInterval(fetchUpcoming, UPCOMING_CACHE_DURATION);
-
-fetchUpcoming();
+import { upcomingShowsStore } from '../stores'; 
 
 const getUpcoming = async (
   req: Request,
@@ -41,7 +7,7 @@ const getUpcoming = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    res.send(upcoming);
+    res.send(upcomingShowsStore.getData());
   } catch (error) {
     next(error);
   }

--- a/src/handlers/spinsHandlers.ts
+++ b/src/handlers/spinsHandlers.ts
@@ -1,30 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import { currentPlaylist } from './playlistsHandlers';
-import { getLogger } from '../logger';
-import { SpinsResponse } from '@wnyu/spinitron-sdk';
-const logger = getLogger(__filename);
-
-let currentSpins: SpinsResponse | undefined;
-
-const UPCOMING_CACHE_DURATION = 3 * 60 * 1000;
-
-async function fetchCurrentSpins() {
-  try {
-    const url = `${process.env.SPINITRON_API_URL}/spins?${`playlist_id=${currentPlaylist?.items[0]?.id}&count=50` ?? ''}`;
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
-    });
-    const spinsData = (await response.json()) as SpinsResponse;
-    currentSpins = spinsData;
-    logger.info(`Spins updated at ${Date.now()}`);
-  } catch (error) {
-    logger.error(error);
-  }
-}
-
-setInterval(fetchCurrentSpins, UPCOMING_CACHE_DURATION);
-
-fetchCurrentSpins();
+import { currentSpinsStore } from '../stores';
 
 const getCurrentSpins = async (
   req: Request,
@@ -32,7 +7,7 @@ const getCurrentSpins = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    res.send(currentSpins);
+    res.send(currentSpinsStore.getData());
   } catch (error) {
     next(error);
   }
@@ -82,5 +57,3 @@ export const spinsHandlers = {
   getSpinById,
   getCurrentSpins,
 };
-
-export { currentSpins };

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -1,0 +1,20 @@
+/*
+ * Abstract class used to define in-memory stores
+ */
+class Store<T> {
+  private data: T;
+
+  public constructor(data: T) {
+    this.data = data;
+  }
+
+  public getData(): T {
+    return this.data;
+  }
+
+  public setData(newData: T): void {
+    this.data = newData;
+  }
+}
+
+export default Store;

--- a/src/stores/currentPlaylistStore.ts
+++ b/src/stores/currentPlaylistStore.ts
@@ -1,0 +1,30 @@
+import type { Playlist, PlaylistsResponse } from '@wnyu/spinitron-sdk';
+import Store from './Store';
+import { getLogger } from '../logger';
+const logger = getLogger(__filename);
+
+const currentPlaylistStore = new Store<Playlist[]>([]);
+
+const CURRENT_PLAYLIST_CACHE_DURATION = 5 * 60 * 1000;
+
+async function fetchCurrentPlaylist() {
+  try {
+    const searchParams = new URLSearchParams({
+      count: '1',
+    }).toString();
+    const url = `${process.env.SPINITRON_API_URL}/playlists?${searchParams}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
+    });
+    const playlistData = (await response.json()) as PlaylistsResponse;
+    currentPlaylistStore.setData(playlistData.items);
+    logger.info(`Playlist updated at ${Date.now()}`);
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+setInterval(fetchCurrentPlaylist, CURRENT_PLAYLIST_CACHE_DURATION);
+
+fetchCurrentPlaylist();
+export { currentPlaylistStore };

--- a/src/stores/currentSpinsStore.ts
+++ b/src/stores/currentSpinsStore.ts
@@ -1,0 +1,30 @@
+import type { Spin, SpinsResponse } from '@wnyu/spinitron-sdk';
+import { getLogger } from '../logger';
+import Store from './Store';
+import { currentPlaylistStore } from './currentPlaylistStore';
+
+const logger = getLogger(__filename);
+
+const currentSpinsStore = new Store<Spin[]>([]);
+
+const CURRENT_SPINS_CACHE_DURATION = 3 * 60 * 1000;
+
+async function fetchCurrentSpins() {
+  try {
+    const url = `${process.env.SPINITRON_API_URL}/spins?${`playlist_id=${currentPlaylistStore.getData()[0]?.id}&count=50` ?? ''}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
+    });
+    const spinsData = (await response.json()) as SpinsResponse;
+    currentSpinsStore.setData(spinsData.items);
+    logger.info(`Spins updated at ${Date.now()}`);
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+setInterval(fetchCurrentSpins, CURRENT_SPINS_CACHE_DURATION);
+
+fetchCurrentSpins();
+
+export { currentSpinsStore };

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,4 @@
+export * from './metadataStore';
+export * from './currentPlaylistStore';
+export * from './upcomingShowsStore';
+export * from './currentSpinsStore';

--- a/src/stores/metadataStore.ts
+++ b/src/stores/metadataStore.ts
@@ -1,0 +1,6 @@
+import type { SpinitronMetadata } from '@wnyu/spinitron-sdk';
+import Store from './Store';
+
+const metadataStore = new Store<SpinitronMetadata>({});
+
+export { metadataStore };

--- a/src/stores/upcomingShowsStore.ts
+++ b/src/stores/upcomingShowsStore.ts
@@ -1,0 +1,37 @@
+import type { Show, ShowsResponse } from '@wnyu/spinitron-sdk';
+import { getLogger } from '../logger';
+import Store from './Store';
+
+const logger = getLogger(__filename);
+
+const upcomingShowsStore = new Store<Show[]>([]);
+
+const UPCOMING_SHOWS_CACHE_DURATION = 30 * 60 * 1000;
+
+async function fetchUpcoming() {
+  try {
+    const start = new Date().toISOString();
+    const end = new Date(
+      new Date().setDate(new Date().getDate() + 1),
+    ).toISOString();
+    const searchParams = new URLSearchParams({
+      start,
+      end,
+    }).toString();
+    const url = `${process.env.SPINITRON_API_URL}/shows?${searchParams}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
+    });
+    const showData = (await response.json()) as ShowsResponse;
+    upcomingShowsStore.setData(showData.items);
+    logger.info(`Upcoming shows updated at ${start}`);
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+setInterval(fetchUpcoming, UPCOMING_SHOWS_CACHE_DURATION);
+
+fetchUpcoming();
+
+export { upcomingShowsStore };


### PR DESCRIPTION
This commit refactors the existing caches into the new 'stores' directory, and renames them accordingly. The idea here is to separate the caches from the handlers, as they function independent of the api request handling. This improves readability for the handler files, and adopts a pattern that should be helpful when defining stores moving forward. Furthermore, it supports infrastructure that would require multiple stores (such as the current Spins store, which requires the context of the current playlist id, which it can retrieve from the currentPlaylistStore).