### PR TITLE
Refactor Current Route

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Typescript/Express API for proxying requests to Spinitron for WNYU
 
+Much inspiration taken from the [pdc-service repository](https://github.com/PhilanthropyDataCommons/service)
+
 ## Deployment
 
 This API is currently deployed at https://lobster-app-zabc8.ondigitalocean.app/,

--- a/src/handlers/currentHandlers.ts
+++ b/src/handlers/currentHandlers.ts
@@ -1,0 +1,21 @@
+import { currentPlaylistStore, currentSpinsStore } from '../stores';
+import type { NextFunction, Request, Response } from 'express';
+
+const getCurrent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    res.send({
+      playlist: currentPlaylistStore.getData()[0],
+      spins: currentSpinsStore.getData(),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const currentHandlers = {
+  getCurrent,
+};

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,0 +1,6 @@
+export * from './currentHandlers';
+export * from './metadataHandlers';
+export * from './personasHandlers';
+export * from './playlistsHandlers';
+export * from './showsHandlers';
+export * from './spinsHandlers';

--- a/src/handlers/playlistsHandlers.ts
+++ b/src/handlers/playlistsHandlers.ts
@@ -1,17 +1,4 @@
-import { currentPlaylistStore } from '../stores';
 import type { NextFunction, Request, Response } from 'express';
-
-const getCurrentPlaylist = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
-  try {
-    res.send(currentPlaylistStore.getData());
-  } catch (error) {
-    next(error);
-  }
-};
 
 const getPlaylists = async (
   req: Request,
@@ -57,5 +44,4 @@ const getPlaylistById = async (
 export const playlistsHandlers = {
   getPlaylists,
   getPlaylistById,
-  getCurrentPlaylist,
 };

--- a/src/handlers/spinsHandlers.ts
+++ b/src/handlers/spinsHandlers.ts
@@ -1,17 +1,4 @@
-import { currentSpinsStore } from '../stores';
 import type { NextFunction, Request, Response } from 'express';
-
-const getCurrentSpins = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
-  try {
-    res.send(currentSpinsStore.getData());
-  } catch (error) {
-    next(error);
-  }
-};
 
 const getSpins = async (
   req: Request,
@@ -57,5 +44,4 @@ const getSpinById = async (
 export const spinsHandlers = {
   getSpins,
   getSpinById,
-  getCurrentSpins,
 };

--- a/src/routers/currentRouter.ts
+++ b/src/routers/currentRouter.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { currentHandlers } from '../handlers';
+
+const currentRouter = express.Router();
+
+currentRouter.get('/', currentHandlers.getCurrent);
+
+export { currentRouter };

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -5,6 +5,7 @@ import { playlistsRouter } from './playlistsRouter';
 import { spinsRouter } from './spinsRouter';
 import { metadataRouter } from './metadataRouter';
 import { healthCheckRouter } from './healthCheckRouter';
+import { currentRouter } from './currentRouter';
 
 const rootRouter = express.Router();
 
@@ -13,6 +14,7 @@ rootRouter.use('/shows', showsRouter);
 rootRouter.use('/playlists', playlistsRouter);
 rootRouter.use('/spins', spinsRouter);
 rootRouter.use('/metadata', metadataRouter);
+rootRouter.use('/current', currentRouter);
 rootRouter.use('/', healthCheckRouter);
 
 export { rootRouter };

--- a/src/routers/playlistsRouter.ts
+++ b/src/routers/playlistsRouter.ts
@@ -5,6 +5,5 @@ const playlistsRouter = express.Router();
 
 playlistsRouter.get('/', playlistsHandlers.getPlaylists);
 playlistsRouter.get('/:id', playlistsHandlers.getPlaylistById);
-playlistsRouter.get('/current/playlist', playlistsHandlers.getCurrentPlaylist);
 
 export { playlistsRouter };

--- a/src/routers/spinsRouter.ts
+++ b/src/routers/spinsRouter.ts
@@ -5,6 +5,5 @@ const spinsRouter = express.Router();
 
 spinsRouter.get('/', spinsHandlers.getSpins);
 spinsRouter.get('/:id', spinsHandlers.getSpinById);
-spinsRouter.get('/current/spins', spinsHandlers.getCurrentSpins);
 
 export { spinsRouter };


### PR DESCRIPTION
This commit gets rid of the separate getCurrentSpins and getCurrentPlaylist routes and combines them into one route, '/current', which returns the stored information for both fields. The separate 'spins/current/spins' and '/playlists/current/playlist' routes were both ugly to look at and meant that we would need to poll our api twice to get the information, when we are perfectly able to provide it in one call.