### PR TITLE
Add Metadata to Current

### DIFF
--- a/src/handlers/currentHandlers.ts
+++ b/src/handlers/currentHandlers.ts
@@ -1,4 +1,8 @@
-import { currentPlaylistStore, currentSpinsStore } from '../stores';
+import {
+  currentPlaylistStore,
+  currentSpinsStore,
+  metadataStore,
+} from '../stores';
 import type { NextFunction, Request, Response } from 'express';
 
 const getCurrent = async (
@@ -10,6 +14,7 @@ const getCurrent = async (
     res.send({
       playlist: currentPlaylistStore.getData()[0],
       spins: currentSpinsStore.getData(),
+      metadata: metadataStore.getData(),
     });
   } catch (error) {
     next(error);


### PR DESCRIPTION
This one-line commit adds the metadata (as recieved from spinitron's metadata push api) to the current GET endpoint, which will give us access to the metadata data on request. This was done specifically to ensure that we have access to the current dj name when we poll for current data, as that would otherwise be another request.