### PR TITLE
Fix Persona By Id route

### DIFF
--- a/src/routers/personasRouter.ts
+++ b/src/routers/personasRouter.ts
@@ -3,7 +3,7 @@ import { personasHandlers } from '../handlers/personasHandlers';
 
 const personasRouter = express.Router();
 
-personasRouter.use('/', personasHandlers.getPersonas);
+personasRouter.get('/', personasHandlers.getPersonas);
 personasRouter.get('/:id', personasHandlers.getPersonaById);
 
 export { personasRouter };


### PR DESCRIPTION
This commit fixes a typo in the personasRouter file that was causing the getPersonaById route to be overided