### PR TITLE
Add Personas Store and Error Handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
         "newlines-between": "never"
       }
     ],
-    "@typescript-eslint/no-misused-promises": "off"
+    "@typescript-eslint/no-misused-promises": "off",
+    "no-underscore-dangle": "off"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:node": "tsc -p tsconfig.json",
     "format": "prettier . --write",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc",
+    "lint-fix": "eslint ./src --ext .ts --max-warnings=0 --fix",
     "lint:eslint": "eslint ./src --ext .ts --max-warnings=0",
     "lint:tsc": "tsc --noEmit -p tsconfig.json",
     "lint:prettier": "prettier . --check",

--- a/src/ajv.ts
+++ b/src/ajv.ts
@@ -1,0 +1,5 @@
+import Ajv from 'ajv';
+
+export const ajv = new Ajv({
+  coerceTypes: true,
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ app.use(
 );
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
-app.use(errorHandler);
 app.use('/', rootRouter);
+app.use(errorHandler);
 
 export { app };

--- a/src/errors/InputValidationError.ts
+++ b/src/errors/InputValidationError.ts
@@ -1,0 +1,3 @@
+import { ValidationError } from './ValidationError';
+
+export class InputValidationError extends ValidationError {}

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,0 +1,6 @@
+export class NotFoundError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/errors/ValidationError.ts
+++ b/src/errors/ValidationError.ts
@@ -1,0 +1,13 @@
+// This error was donated by the TV Kitchen project / Bad Idea Factory
+// https://github.com/tvkitchen/countertop/blob/main/src/errors/ValidationError.ts
+import type { ErrorObject } from 'ajv';
+
+export class ValidationError extends Error {
+  public errors: ErrorObject[];
+
+  public constructor(message: string, errors: ErrorObject[]) {
+    super(message);
+    this.name = this.constructor.name;
+    this.errors = errors;
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,2 @@
+export * from './InputValidationError';
+export * from './NotFoundError';

--- a/src/routers/personasRouter.ts
+++ b/src/routers/personasRouter.ts
@@ -4,6 +4,6 @@ import { personasHandlers } from '../handlers/personasHandlers';
 const personasRouter = express.Router();
 
 personasRouter.get('/', personasHandlers.getPersonas);
-personasRouter.get('/:id', personasHandlers.getPersonaById);
+personasRouter.get('/:personaId', personasHandlers.getPersonaById);
 
 export { personasRouter };

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,5 @@
 export * from './currentPlaylistStore';
 export * from './currentSpinsStore';
 export * from './metadataStore';
+export * from './personasStore';
 export * from './upcomingShowsStore';

--- a/src/stores/personasStore.ts
+++ b/src/stores/personasStore.ts
@@ -1,0 +1,59 @@
+import { getLogger } from '../logger';
+import { Store } from './Store';
+import type { Persona, PersonasResponse } from '@wnyu/spinitron-sdk';
+
+const logger = getLogger(__filename);
+
+const personasStore = new Store<Persona[]>([]);
+
+const PERSONAS_CACHE_DURATION = 60 * 60 * 1000;
+
+const fetchAllPersonas = async (
+  page = 1,
+  accumulatedPersonas: Persona[] = [],
+): Promise<Persona[]> => {
+  try {
+    const searchParams = new URLSearchParams({
+      page: page.toString(),
+    }).toString();
+    const url = `${process.env.SPINITRON_API_URL}/personas?${searchParams}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
+    });
+    const personasData = (await response.json()) as PersonasResponse;
+
+    const newAccumulatedPersonas = [
+      ...accumulatedPersonas,
+      ...personasData.items,
+    ];
+
+    const { currentPage } = personasData._meta;
+    const { pageCount } = personasData._meta;
+
+    if (currentPage < pageCount) {
+      return await fetchAllPersonas(currentPage + 1, newAccumulatedPersonas);
+    }
+    return newAccumulatedPersonas;
+  } catch (error) {
+    logger.error(`Error fetching personas on page ${page}:`, error);
+    throw error;
+  }
+};
+
+const fetchAndStorePersonas = async () => {
+  try {
+    const allPersonas = await fetchAllPersonas();
+    personasStore.setData(allPersonas);
+    logger.info(`Personas store updated at ${Date.now()}`);
+  } catch (error) {
+    logger.error('Failed to update personas store:', error);
+  }
+};
+
+setInterval(fetchAndStorePersonas, PERSONAS_CACHE_DURATION);
+
+fetchAndStorePersonas().catch((error) =>
+  logger.info('Personas Store failed to initialize', error),
+);
+
+export { personasStore };

--- a/src/types/Id.ts
+++ b/src/types/Id.ts
@@ -1,0 +1,10 @@
+import { ajv } from '../ajv';
+import type { JSONSchemaType } from 'ajv';
+
+export type Id = number;
+
+export const idSchema: JSONSchemaType<Id> = {
+  type: 'integer',
+};
+
+export const isId = ajv.compile(idSchema);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './Id';


### PR DESCRIPTION
This commit adds a personas store which is used to cache persona data at a regular interval, every hour. This is slightly more involved than the other stores as it needs to query multiple pages of data (or at least potentially multiple) as the number of personas we have can grow. However, since that value should never be more than a thousand (at VERY most) it seems sustainable to just query every page once every hour or so. Interval length can be increased if needed. It also fleshes out the error handling in the repository to actually include useful error messages, instead of just generic errors. AND, now the error handling middleware is actually functioning, which I had not realized it was not due to the middleware import order.