### PR TITLE
Force Persona Expansion in Shows routes

### DIFF
--- a/src/handlers/showsHandlers.ts
+++ b/src/handlers/showsHandlers.ts
@@ -19,11 +19,7 @@ const getShows = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const baseUrl = `${process.env.SPINITRON_API_URL}/shows`;
-    const searchParams = new URLSearchParams(
-      req.query as unknown as string,
-    ).toString();
-    const url = searchParams ? `${baseUrl}?${searchParams}` : baseUrl;
+    const url = `${process.env.SPINITRON_API_URL}/shows?expand=personas`;
 
     const data = await fetch(url, {
       headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
@@ -42,7 +38,7 @@ const getShowById = async (
 ): Promise<void> => {
   try {
     const data = await fetch(
-      `${process.env.SPINITRON_API_URL}/shows/${req.params.id}`,
+      `${process.env.SPINITRON_API_URL}/shows/${req.params.id}?expand=personas`,
       {
         headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },
       },

--- a/src/stores/upcomingShowsStore.ts
+++ b/src/stores/upcomingShowsStore.ts
@@ -17,6 +17,7 @@ async function fetchUpcoming(): Promise<void> {
     const searchParams = new URLSearchParams({
       start,
       end,
+      expand: 'personas',
     }).toString();
     const url = `${process.env.SPINITRON_API_URL}/shows?${searchParams}`;
     const response = await fetch(url, {


### PR DESCRIPTION
This commit adds a 'expand=personas' parameter to all shows routes, which makes them include the personas as an array in their response. It also drops the url parameters pattern that allows for endpoints to receive a variable number of search queries (it drops this pattern in the shows handlers). These are being dropped here principally because they didn't seem to work, but also because ultimately we should handle all parameters to spinitron in the API, not on the frontend. Some future commit should remove all those url search parameter setups in the other handlers.