### PR TITLE
Add configurable show limit for show fetch

### DIFF
--- a/src/handlers/showsHandlers.ts
+++ b/src/handlers/showsHandlers.ts
@@ -1,6 +1,12 @@
 import { upcomingShowsStore } from '../stores';
 import type { NextFunction, Request, Response } from 'express';
 
+// We prefetch all shows to get the schedule, but by default the shows
+// endpoint is paginated at 20. If there are ever more than 150 active
+// shows in our schedule, we can increase the variable size
+
+const SHOW_LIMIT = '150';
+
 const getUpcoming = async (
   req: Request,
   res: Response,
@@ -19,7 +25,7 @@ const getShows = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const url = `${process.env.SPINITRON_API_URL}/shows?expand=personas`;
+    const url = `${process.env.SPINITRON_API_URL}/shows?expand=personas&count=${SHOW_LIMIT}`;
 
     const data = await fetch(url, {
       headers: { Authorization: `Bearer ${process.env.SPINITRON_API_KEY}` },


### PR DESCRIPTION
This commit adds a configurable variable for our api to dictate the number of shows returned in a single show call. This was originally handled by the front-end when it was proxying query parameters to spinitron, but since we have moved away from that, we want to now handle retrieving all shows in our database on our api end.